### PR TITLE
fix: "Merge pull request #11 from uncurated-tests/faster-transition"

### DIFF
--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,4 +1,5 @@
-import useSWR from 'swr'
+import { useEffect } from 'react'
+import useSWR, { mutate } from 'swr'
 
 // Define types for our data
 export interface PostSummary {
@@ -23,6 +24,34 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json())
 // Custom hook to fetch all posts
 export function usePosts() {
   const { data, error, isLoading } = useSWR<PostSummary[]>('/api/posts', fetcher)
+
+  // Pre-populate individual post caches when posts list is loaded
+  useEffect(() => {
+    if (data && !error) {
+      // Fetch and cache individual posts in parallel
+      data.forEach(async (postSummary) => {
+        try {
+          // Ensure postSummary has a valid structure
+          const completePostSummary = {
+            ...postSummary,
+            twitter: {
+              followers: (postSummary as any).twitter?.followers || 0,
+              username: (postSummary as any).twitter?.username || ''
+            }
+          };
+
+          // Pre-populate the cache for this individual post
+          mutate(`/api/posts/${postSummary.slug}`, completePostSummary, {
+            revalidate: false,
+            populateCache: true,
+          })
+        } catch (error) {
+          // Silently fail
+          console.warn(`Failed to preload post ${postSummary.slug}:`, error)
+        }
+      })
+    }
+  }, [data, error])
 
   return {
     posts: data,


### PR DESCRIPTION
The issue is caused by an undefined property access related to the 'followers' field when navigating from the post list. In the commit `d5d44eabf19a3b5dafb9211fc681f5c99c62f0f1`, the `usePosts` hook was modified to pre-populate post caches, but there might be an assumption that data would not be missing certain fields. When preloading, it doesn't ensure that all fields like 'followers' are present or correctly initialized, leading to a potential `undefined` error when accessing properties on these objects.

To fix the issue, ensure that when preloading posts, all fields that might be accessed later (such as 'followers') are correctly checked or initialized.

In the `usePosts` hook:

```
data.forEach(async (postSummary) => {
  try {
    // Ensure postSummary has a valid structure
    const completePostSummary = {
      ...postSummary,
      twitter: {
        followers: postSummary.twitter?.followers || 0,
        username: postSummary.twitter?.username || ''
      }
    };

    // Pre-populate the cache for this individual post
    mutate(`/api/posts/${postSummary.slug}`, completePostSummary, {
      revalidate: false,
      populateCache: true,
    })
  } catch (error) {
    // Silently fail
    console.warn(`Failed to preload post ${postSummary.slug}:`, error)
  }
});
```