### PR TITLE
fix: "Merge pull request #11 from uncurated-tests/faster-transition"

### DIFF
--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -31,8 +31,10 @@ export function usePosts() {
       // Fetch and cache individual posts in parallel
       data.forEach(async (postSummary) => {
         try {
+          // Fetch the full post data
+          const post = await fetcher(`/api/posts/${postSummary.slug}`)
           // Pre-populate the cache for this individual post
-          mutate(`/api/posts/${postSummary.slug}`, postSummary, {
+          mutate(`/api/posts/${postSummary.slug}`, post, {
             revalidate: false,
             populateCache: true,
           })
@@ -63,4 +65,4 @@ export function usePost(slug: string) {
     isLoading,
     isError: error
   }
-} 
+}


### PR DESCRIPTION
The issue is likely caused by the attempt to pre-populate the cache for individual posts when the posts list is loaded. This involves pre-loading data, including the "followers" property, which is accessed later when selecting a specific post from the list. If this property is missing or not properly handled, it results in an undefined error when attempting to read its properties, hence the crash.

To fix the issue, ensure that the data structure being cached includes all necessary properties, especially the "followers" property in the 'twitter' object. Also, add checks for undefined properties before accessing them. For example, ensure that the 'followers' property is checked:

`if (data.twitter && typeof data.twitter.followers !== 'undefined') { /* Access followers */ } else { /* Handle missing data */ }`