### PR TITLE
fix: "Merge pull request #11 from uncurated-tests/faster-transition"

### DIFF
--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,4 +1,5 @@
-import useSWR from 'swr'
+import { useEffect } from 'react'
+import useSWR, { mutate } from 'swr'
 
 // Define types for our data
 export interface PostSummary {
@@ -23,6 +24,31 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json())
 // Custom hook to fetch all posts
 export function usePosts() {
   const { data, error, isLoading } = useSWR<PostSummary[]>('/api/posts', fetcher)
+
+  // Pre-populate individual post caches when posts list is loaded
+  useEffect(() => {
+    if (data && !error) {
+      // Fetch and cache individual posts in parallel
+      data.forEach(async (postSummary) => {
+        try {
+          // Add default values for twitter object if they are missing
+          mutate(`/api/posts/${postSummary.slug}`, {
+            ...postSummary,
+            twitter: {
+              followers: postSummary.twitter?.followers || 0,
+              username: postSummary.twitter?.username || ''
+            }
+          }, {
+            revalidate: false,
+            populateCache: true,
+          })
+        } catch (error) {
+          // Silently fail - individual post will be fetched when needed
+          console.warn(`Failed to preload post ${postSummary.slug}:`, error)
+        }
+      })
+    }
+  }, [data, error])
 
   return {
     posts: data,


### PR DESCRIPTION
The root cause of the crash appears to be related to the changes in the `usePosts` hook in commit `d5d44eabf19a3b5dafb9211fc681f5c99c62f0f1`. This commit introduced a pre-fetching mechanism for individual post data, utilizing the SWR mutate function to populate cache entries for each post after the posts list is loaded. However, the `Post` interface expects a nested 'twitter' object, which includes a 'followers' property. If any post's data is missing this structure when pre-fetched, the page will crash when attempting to access this property. This aligns with the error observed ('TypeError: Cannot read properties of undefined').

To fix this issue, ensure that the pre-fetching logic correctly handles posts that might not have a 'twitter' object or 'followers' property. This can be done by modifying the `mutate` function to validate the structure of each post and provide default values if necessary. Additionally, checking for undefined properties before utilizing them in the application can prevent such errors.

```javascript
mutate(`/api/posts/${postSummary.slug}`, {
  ...postSummary,
  twitter: {
    followers: postSummary.twitter?.followers || 0,
    username: postSummary.twitter?.username || ''
  }
}, {
  revalidate: false,
  populateCache: true,
});
```