### PR TITLE
Revert "Merge pull request #11 from uncurated-tests/faster-transition"

### DIFF
--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,5 +1,4 @@
-import { useEffect } from 'react'
-import useSWR, { mutate } from 'swr'
+import useSWR from 'swr'
 
 // Define types for our data
 export interface PostSummary {
@@ -24,25 +23,6 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json())
 // Custom hook to fetch all posts
 export function usePosts() {
   const { data, error, isLoading } = useSWR<PostSummary[]>('/api/posts', fetcher)
-
-  // Pre-populate individual post caches when posts list is loaded
-  useEffect(() => {
-    if (data && !error) {
-      // Fetch and cache individual posts in parallel
-      data.forEach(async (postSummary) => {
-        try {
-          // Pre-populate the cache for this individual post
-          mutate(`/api/posts/${postSummary.slug}`, postSummary, {
-            revalidate: false,
-            populateCache: true,
-          })
-        } catch (error) {
-          // Silently fail - individual post will be fetched when needed
-          console.warn(`Failed to preload post ${postSummary.slug}:`, error)
-        }
-      })
-    }
-  }, [data, error])
 
   return {
     posts: data,


### PR DESCRIPTION
Reverts d5d44ea.

The issue reported is an uncaught exception when accessing 'followers' of an undefined property. The commit with SHA `d5d44eabf19a3b5dafb9211fc681f5c99c62f0f1` introduces a change where individual post data is pre-loaded using the SWR 'mutate' function. However, the data structure expected includes a 'twitter' object with 'followers,' but this might not be present for every post in the list. When clicking from the list, the application tries to access 'followers' from this pre-loaded but incomplete data, leading to the described crash.