### PR TITLE
fix: "Merge pull request #11 from uncurated-tests/faster-transition"

### DIFF
--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -31,8 +31,11 @@ export function usePosts() {
       // Fetch and cache individual posts in parallel
       data.forEach(async (postSummary) => {
         try {
-          // Pre-populate the cache for this individual post
-          mutate(`/api/posts/${postSummary.slug}`, postSummary, {
+          // Pre-populate the cache for this individual post with default twitter data
+          mutate(`/api/posts/${postSummary.slug}`, {
+            ...postSummary,
+            twitter: { followers: 0, username: '' }
+          }, {
             revalidate: false,
             populateCache: true,
           })


### PR DESCRIPTION
The code that most likely causes the issue is introduced in the commit `d5d44eabf19a3b5dafb9211fc681f5c99c62f0f1`. This commit adds a `useEffect` hook that pre-loads individual posts' data into cache when the posts list is loaded. However, the `mutate` call used to pre-populate post cache does not include the `twitter` object with `followers` and `username` keys. When navigating from the list and trying to access these properties, they are undefined, leading to the TypeError.

To fix this issue, modify the `mutate` call within the `useEffect` to include the `twitter` object with default values for `followers` and `username`:  

```javascript
useEffect(() => {
  if (data && !error) {
    data.forEach(async (postSummary) => {
      try {
        // Include default twitter data
        mutate(`/api/posts/${postSummary.slug}`, {
          ...postSummary,
          twitter: { followers: 0, username: '' }
        }, {
          revalidate: false,
          populateCache: true,
        })
      } catch (error) {
        console.warn(`Failed to preload post ${postSummary.slug}:`, error)
      }
    })
  }
}, [data, error])
```