### PR TITLE
Revert "Merge pull request #11 from uncurated-tests/faster-transition"

### DIFF
--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,5 +1,4 @@
-import { useEffect } from 'react'
-import useSWR, { mutate } from 'swr'
+import useSWR from 'swr'
 
 // Define types for our data
 export interface PostSummary {
@@ -24,25 +23,6 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json())
 // Custom hook to fetch all posts
 export function usePosts() {
   const { data, error, isLoading } = useSWR<PostSummary[]>('/api/posts', fetcher)
-
-  // Pre-populate individual post caches when posts list is loaded
-  useEffect(() => {
-    if (data && !error) {
-      // Fetch and cache individual posts in parallel
-      data.forEach(async (postSummary) => {
-        try {
-          // Pre-populate the cache for this individual post
-          mutate(`/api/posts/${postSummary.slug}`, postSummary, {
-            revalidate: false,
-            populateCache: true,
-          })
-        } catch (error) {
-          // Silently fail - individual post will be fetched when needed
-          console.warn(`Failed to preload post ${postSummary.slug}:`, error)
-        }
-      })
-    }
-  }, [data, error])
 
   return {
     posts: data,


### PR DESCRIPTION
Reverts d5d44ea.

The code that most likely causes the issue is introduced in the commit `d5d44eabf19a3b5dafb9211fc681f5c99c62f0f1`. This commit adds a `useEffect` hook that pre-loads individual posts' data into cache when the posts list is loaded. However, the `mutate` call used to pre-populate post cache does not include the `twitter` object with `followers` and `username` keys. When navigating from the list and trying to access these properties, they are undefined, leading to the TypeError.