### PR TITLE
fix: "Merge pull request #11 from uncurated-tests/faster-transition"

### DIFF
--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,4 +1,5 @@
-import useSWR from 'swr'
+import { useEffect } from 'react'
+import useSWR, { mutate } from 'swr'
 
 // Define types for our data
 export interface PostSummary {
@@ -23,6 +24,27 @@ const fetcher = (url: string) => fetch(url).then((res) => res.json())
 // Custom hook to fetch all posts
 export function usePosts() {
   const { data, error, isLoading } = useSWR<PostSummary[]>('/api/posts', fetcher)
+
+  // Pre-populate individual post caches when posts list is loaded
+  useEffect(() => {
+    if (data && !error) {
+      // Fetch and cache individual posts in parallel
+      data.forEach(async (postSummary) => {
+        try {
+          // Fetch full post details
+          const postDetail = await fetch(`/api/posts/${postSummary.slug}`).then(res => res.json());
+          // Pre-populate the cache with full post details
+          mutate(`/api/posts/${postSummary.slug}`, postDetail, {
+            revalidate: false,
+            populateCache: true,
+          });
+        } catch (error) {
+          // Silently fail - individual post will be fetched when needed
+          console.warn(`Failed to preload post details for ${postSummary.slug}:`, error);
+        }
+      });
+    }
+  }, [data, error]);
 
   return {
     posts: data,


### PR DESCRIPTION
The issue arises when trying to access properties of undefined when navigating from the blog post list. This behavior is consistent with the changes made in the commit `d5d44eabf19a3b5dafb9211fc681f5c99c62f0f1`, which preloads individual post data into the cache. The problem is likely occurring because while the post summary is cached, the full post data, which includes the `twitter` property, is not fetched, leading to an undefined `twitter` object when the post page expects it.

To fix the issue, ensure that the full post data is loaded before the transition is considered complete. Modify the cache pre-population to also include fetching the complete post details:

```javascript
useEffect(() => {
  if (data && !error) {
    data.forEach(async (postSummary) => {
      try {
        const postDetail = await fetch(`/api/posts/${postSummary.slug}`).then(res => res.json());
        mutate(`/api/posts/${postSummary.slug}`, postDetail, {
          revalidate: false,
          populateCache: true,
        });
      } catch (error) {
        console.warn(`Failed to preload post details for ${postSummary.slug}:`, error);
      }
    });
  }
}, [data, error]);
```